### PR TITLE
fix: Fix triggering many upload events

### DIFF
--- a/solutions/uploader/Program.cs
+++ b/solutions/uploader/Program.cs
@@ -1,12 +1,40 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Azure;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
-    .ConfigureServices(services => {
+    .ConfigureServices((hostContext, services) => {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
+        services.Configure<LoggerFilterOptions>(options =>
+        {
+            LoggerFilterRule toRemove = options.Rules.FirstOrDefault(rule => rule.ProviderName
+                == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
+
+            if (toRemove is not null)
+            {
+                options.Rules.Remove(toRemove);
+            }
+        });
+        services.AddAzureClients(clientBuilder => {
+            clientBuilder.AddBlobServiceClient(hostContext.Configuration.GetSection("AudioUploadStorage")).WithName("audioUploader");
+        });
+    })
+    .ConfigureAppConfiguration((hostContext, config) =>
+    {
+        config.AddJsonFile("host.json", optional: true);
+    })
+    .ConfigureLogging((hostingContext, logging) =>
+    {
+        logging.AddApplicationInsights(console =>
+        {
+            console.IncludeScopes = true;
+        });
+        logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
     })
     .Build();
 

--- a/solutions/uploader/Uploader.csproj
+++ b/solutions/uploader/Uploader.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.11.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />

--- a/src/uploader/Program.cs
+++ b/src/uploader/Program.cs
@@ -3,10 +3,11 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Azure;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
-    .ConfigureServices(services => {
+    .ConfigureServices((hostContext, services) => {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
         services.Configure<LoggerFilterOptions>(options =>
@@ -18,6 +19,9 @@ var host = new HostBuilder()
             {
                 options.Rules.Remove(toRemove);
             }
+        });
+        services.AddAzureClients(clientBuilder => {
+            clientBuilder.AddBlobServiceClient(hostContext.Configuration.GetSection("AudioUploadStorage")).WithName("audioUploader");
         });
     })
     .ConfigureAppConfiguration((hostContext, config) =>

--- a/src/uploader/Uploader.csproj
+++ b/src/uploader/Uploader.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.11.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />


### PR DESCRIPTION
Replace the native Blob Output binding with the SDK of Blob storage to upload audio files.
This would allow creating the blob with 1 API call on Blob storage side hence triggering a single BlobCreated event (instead of 3).

noissue