### PR TITLE
fix: Ensure SpeechToTextService calls are successful 

### DIFF
--- a/solutions/processor/AudioTranscriptionOrchestration.cs
+++ b/solutions/processor/AudioTranscriptionOrchestration.cs
@@ -74,7 +74,7 @@ namespace FuncDurable
             var jobUri = await context.CallActivityAsync<string>(nameof(StartTranscription), audioFile);
             audioFile.JobUri = jobUri;
 
-            DateTime endTime = context.CurrentUtcDateTime.AddMinutes(2);
+            DateTime endTime = context.CurrentUtcDateTime.AddMinutes(5);
 
             while (context.CurrentUtcDateTime < endTime)
             {

--- a/solutions/processor/AudioTranscriptionOrchestration.cs
+++ b/solutions/processor/AudioTranscriptionOrchestration.cs
@@ -83,7 +83,7 @@ namespace FuncDurable
 
                 if (!context.IsReplaying) { logger.LogInformation($"Status of the transcription of {audioFile.Id}: {status}"); }
 
-                if (status == "Succeeded" || status == "Failed")
+                if (status == "Succeeded")
                 {
                     // Step3: Get transcription
                     string transcription = await context.CallActivityAsync<string>(nameof(GetTranscription), audioFile);
@@ -108,6 +108,11 @@ namespace FuncDurable
 
                     if (!context.IsReplaying) { logger.LogInformation($"Finished processing of {audioFile.Id}"); }
                     
+                    break;
+                }
+                else if (status == "Failed")
+                {
+                    if (!context.IsReplaying) { logger.LogInformation($"Transcription of {audioFile.Id} failed."); }
                     break;
                 }
                 else
@@ -161,6 +166,7 @@ namespace FuncDurable
             ILogger logger = executionContext.GetLogger(nameof(EnrichTranscription));
             logger.LogInformation($"Enriching transcription {audioTranscription.Id}");
             audioTranscription.Completion = response.Content;
+            logger.LogInformation($"Completion: {audioTranscription.Completion}");
             return audioTranscription;
         }
 

--- a/src/processor/AudioTranscriptionOrchestration.cs
+++ b/src/processor/AudioTranscriptionOrchestration.cs
@@ -74,7 +74,7 @@ namespace FuncDurable
             var jobUri = await context.CallActivityAsync<string>(nameof(StartTranscription), audioFile);
             audioFile.JobUri = jobUri;
 
-            DateTime endTime = context.CurrentUtcDateTime.AddMinutes(2);
+            DateTime endTime = context.CurrentUtcDateTime.AddMinutes(5);
 
             while (context.CurrentUtcDateTime < endTime)
             {

--- a/src/processor/AudioTranscriptionOrchestration.cs
+++ b/src/processor/AudioTranscriptionOrchestration.cs
@@ -83,7 +83,7 @@ namespace FuncDurable
 
                 if (!context.IsReplaying) { logger.LogInformation($"Status of the transcription of {audioFile.Id}: {status}"); }
 
-                if (status == "Succeeded" || status == "Failed")
+                if (status == "Succeeded")
                 {
                     // Step3: Get transcription
                     string transcription = await context.CallActivityAsync<string>(nameof(GetTranscription), audioFile);
@@ -108,6 +108,11 @@ namespace FuncDurable
 
                     if (!context.IsReplaying) { logger.LogInformation($"Finished processing of {audioFile.Id}"); }
                     
+                    break;
+                }
+                else if (status == "Failed")
+                {
+                    if (!context.IsReplaying) { logger.LogInformation($"Transcription of {audioFile.Id} failed."); }
                     break;
                 }
                 else


### PR DESCRIPTION
Ensure all calls to the Speech To Text services are successful by checking the response status code before proceeding with the transcription process.

noissue